### PR TITLE
Don't abort out if the group already exists

### DIFF
--- a/dev-local/setuplocaluser.sh
+++ b/dev-local/setuplocaluser.sh
@@ -10,7 +10,7 @@ GNAME=$4
 echo $0
 CFG_ROOT_DIR="$( cd "$( dirname "$0" )/.." >/dev/null 2>&1 && pwd )"
 
-groupadd -g $GID $GNAME
+groupadd -f -g $GID $GNAME
 useradd -u $UID -g $GID $UNAME
 usermod --shell /bin/bash $UNAME
 cd $AOSP_SRC_ROOT


### PR DESCRIPTION
Fixes:

```
+ docker run -it --name rundevmode --rm --mount type=bind,source=/Users/rogerh/Development/aosp,target=/aosp/src --mount type=bind,source=/Users/rogerh/Development/android-studio-builder,target=/aosp/builder --mount type=bind,source=/Users/rogerh/.cache/bazel,target=/home/rogerh/.cache/bazel --mount type=bind,source=/Users/rogerh/.cache/bazelisk,target=/home/rogerh/.cache/bazelisk --mount type=bind,source=/Users/rogerh/.m2,target=/home/rogerh/.m2 --mount type=bind,source=/Users/rogerh/.gradle,target=/home/rogerh/.gradle androidstudio-builder-dev:latest
/aosp/builder/dev-local/setuplocaluser.sh
groupadd: group 'staff' already exists
```